### PR TITLE
Resolve Zip File Upload Issue

### DIFF
--- a/resources/views/themes/upload.blade.php
+++ b/resources/views/themes/upload.blade.php
@@ -1,6 +1,6 @@
 <x-tomato-admin-container label="{{__('Upload New Theme File')}}">
     <x-splade-form class="flex flex-col space-y-4" method="POST" action="{{route('admin.themes.upload.new')}}">
-        <x-splade-file filepond preview accept="application/zip, application/octet-stream " name="theme" label="Theme ZIP file" placeholder="you can upload your theme file here" />
+        <x-splade-file filepond preview accept="zip,application/octet-stream,application/zip,application/x-zip,application/x-zip-compressed" name="theme" label="Theme ZIP file" placeholder="you can upload your theme file here" />
         <div class="flex jusifiy-start gap-4">
             <x-tomato-admin-submit label="{{__('Upload Theme')}}" spinner/>
         </div>


### PR DESCRIPTION
Upon attempting to upload a zip file, an error is encountered, indicating that the system does not support the zip format.

This pull request addresses the issue related to uploading zip files. The error occurs when attempting to upload a zip file, preventing successful file submission.
